### PR TITLE
Nguyenquyhy/16 min max toggle value usage (#78)

### DIFF
--- a/FlightStreamDeck.Core/EnumConverter.cs
+++ b/FlightStreamDeck.Core/EnumConverter.cs
@@ -6,7 +6,7 @@ namespace FlightStreamDeck.Core
     {
         public TOGGLE_EVENT? GetEventEnum(string value)
         {
-            if (value != null && Enum.TryParse(value, true, out TOGGLE_EVENT result))
+            if (value != null && Enum.TryParse(value.Replace(":", "__").Replace(" ", "_"), true, out TOGGLE_EVENT result))
             {
                 return result;
             }
@@ -16,7 +16,7 @@ namespace FlightStreamDeck.Core
 
         public TOGGLE_VALUE? GetVariableEnum(string value)
         {
-            if (value != null && Enum.TryParse(value.Replace(":", "__").Replace(" ", "_"), true, out TOGGLE_VALUE result))
+            if (!float.TryParse(value, out float floatvalue) && value != null && Enum.TryParse(value.Replace(":", "__").Replace(" ", "_"), true, out TOGGLE_VALUE result))
             {
                 return result;
             }

--- a/FlightStreamDeck.Logics/Actions/GenericGaugeAction.cs
+++ b/FlightStreamDeck.Logics/Actions/GenericGaugeAction.cs
@@ -65,6 +65,8 @@ namespace FlightStreamDeck.Logics.Actions
         private TOGGLE_VALUE? displayValue = null;
         private TOGGLE_VALUE? subDisplayValue = null;
         private TOGGLE_VALUE? displayValueBottom = null;
+        private TOGGLE_VALUE? minValue = null;
+        private TOGGLE_VALUE? maxValue = null;
 
         private float currentValue = 0;
         private float currentValueBottom = 0;
@@ -155,8 +157,10 @@ namespace FlightStreamDeck.Logics.Actions
             TOGGLE_VALUE? newDisplayValue = enumConverter.GetVariableEnum(this.settings.DisplayValue);
             TOGGLE_VALUE? newSubDisplayValue = enumConverter.GetVariableEnum(this.settings.SubDisplayValue);
             TOGGLE_VALUE? newDisplayValueBottom = enumConverter.GetVariableEnum(this.settings.DisplayValueBottom);
+            TOGGLE_VALUE? newMinValue = enumConverter.GetVariableEnum(this.settings.MinValue);
+            TOGGLE_VALUE? newMaxValue = enumConverter.GetVariableEnum(this.settings.MaxValue);
 
-            if (newDisplayValue != displayValue || newDisplayValueBottom != displayValueBottom || newSubDisplayValue != subDisplayValue)
+            if (newDisplayValue != displayValue || newDisplayValueBottom != displayValueBottom || newSubDisplayValue != subDisplayValue || newMinValue != minValue || newMaxValue != maxValue)
             {
                 DeRegisterValues();
             }
@@ -165,6 +169,8 @@ namespace FlightStreamDeck.Logics.Actions
             displayValue = newDisplayValue;
             subDisplayValue = newSubDisplayValue;
             displayValueBottom = newDisplayValueBottom;
+            minValue = newMinValue;
+            maxValue = newMaxValue;
 
             RegisterValues();
         }
@@ -198,6 +204,18 @@ namespace FlightStreamDeck.Logics.Actions
                 isUpdated |= currentSubValue != newValue;
                 currentSubValue = newValue;
             }
+            if (minValue.HasValue && e.GenericValueStatus.ContainsKey(minValue.Value))
+            {
+                float.TryParse(e.GenericValueStatus[minValue.Value], out float newValue);
+                isUpdated |= settings.MinValue != newValue.ToString(this.precision);
+                settings.MinValue = newValue.ToString(this.precision);
+            }
+            if (maxValue.HasValue && e.GenericValueStatus.ContainsKey(maxValue.Value))
+            {
+                float.TryParse(e.GenericValueStatus[maxValue.Value], out float newValue);
+                isUpdated |= settings.MaxValue != newValue.ToString(this.precision);
+                settings.MaxValue = newValue.ToString(this.precision);
+            }
 
             if (isUpdated)
             {
@@ -211,6 +229,8 @@ namespace FlightStreamDeck.Logics.Actions
             if (displayValue.HasValue) flightConnector.RegisterSimValue(displayValue.Value);
             if (subDisplayValue.HasValue) flightConnector.RegisterSimValue(subDisplayValue.Value);
             if (displayValueBottom.HasValue) flightConnector.RegisterSimValue(displayValueBottom.Value);
+            if (minValue.HasValue) flightConnector.RegisterSimValue(minValue.Value);
+            if (maxValue.HasValue) flightConnector.RegisterSimValue(maxValue.Value);
         }
 
         private void DeRegisterValues()
@@ -218,6 +238,8 @@ namespace FlightStreamDeck.Logics.Actions
             if (displayValue.HasValue) flightConnector.DeRegisterSimValue(displayValue.Value);
             if (subDisplayValue.HasValue) flightConnector.DeRegisterSimValue(subDisplayValue.Value);
             if (displayValueBottom.HasValue) flightConnector.DeRegisterSimValue(displayValueBottom.Value);
+            if (minValue.HasValue) flightConnector.DeRegisterSimValue(minValue.Value);
+            if (maxValue.HasValue) flightConnector.DeRegisterSimValue(maxValue.Value);
             currentValue = 0;
             currentValueBottom = 0;
             currentSubValue = float.MinValue;
@@ -227,7 +249,6 @@ namespace FlightStreamDeck.Logics.Actions
         {
             if (settings != null)
             {
-                string precision = $"F{((settings.ValuePrecision?.Length ?? 0) > 0 ? settings.ValuePrecision : this.defaultSettings.ValuePrecision)}";
                 float MinValue = settings.MinValue.ConvertTo<float>(this.defaultSettings.MinValue);
                 float MaxValue = settings.MaxValue.ConvertTo<float>(this.defaultSettings.MaxValue);
                 string chartSplit = string.IsNullOrEmpty(settings.ChartSplitValue) ? defaultSettings.ChartSplitValue : settings.ChartSplitValue;
@@ -242,8 +263,8 @@ namespace FlightStreamDeck.Logics.Actions
                         imageLogic.GetCustomGaugeImage(
                             settings.Header,
                             settings.HeaderBottom,
-                            (currentValue * modifier).ToString(precision),
-                            (currentValueBottom * modifier).ToString(precision),
+                            (currentValue * modifier).ToString(this.precision),
+                            (currentValueBottom * modifier).ToString(this.precision),
                             MinValue,
                             MaxValue,
                             settings.DisplayHorizontalValue,
@@ -270,6 +291,14 @@ namespace FlightStreamDeck.Logics.Actions
                         )
                     );
                 }
+            }
+        }
+
+        private string precision
+        {
+            get
+            {
+                return $"F{((settings.ValuePrecision?.Length ?? 0) > 0 ? settings.ValuePrecision : this.defaultSettings.ValuePrecision)}";
             }
         }
     }


### PR DESCRIPTION
* [Ryan Mroczenski] - allow stacking/chaining of linear gauges so you can make a multi button view of a gauge.  Hide chevron/header label if outside min/max range, defined by option checkbox if you want that.

Also changed property types to string from float/int because of how parsing works from the PI -> Action.  It was throwing parsing exceptions when values were missing for the floats/int properties.

* [Ryan Mroczenski] - implementing allowing to grab min/max values from TOGGLE_VALUE variables instead of inputing constants.

* [Ryan Mroczenski] - adding tryparse to float value before trying to parse a enum, so we can nix the checkbox inputs.